### PR TITLE
Modifications to 8 parameter paradigm

### DIFF
--- a/Launch_Control/LaunchControl.py
+++ b/Launch_Control/LaunchControl.py
@@ -134,11 +134,13 @@ class LaunchControl(ControlSurface):
 
         self._on_track_offset.subject = self._session
 
+##This is the device mode that you'll want to make the changes to.
     def _init_device(self):
         make_button = partial(make_launch_control_button, channel=10)
         make_encoder = partial(make_launch_control_encoder, channel=10)
         bottom_encoders, top_encoders = make_all_encoders(u'Device', make_encoder)
-        parameter_controls = top_encoders[:4] + bottom_encoders[:4]
+## Here you change top and bottom encoders to values of :8
+        parameter_controls = top_encoders[:8] + bottom_encoders[:8]
         bank_buttons = [ make_button(identifier, u'Device_Bank_Button_' + str(i), is_pad=True) for i, identifier in enumerate(pad_identifiers) ]
         for button in bank_buttons:
             button.set_on_off_values(Colors.LED_ON, Colors.LED_OFF)
@@ -146,7 +148,8 @@ class LaunchControl(ControlSurface):
         self._device_bank_registry = DeviceBankRegistry()
         self._device = DeviceComponent(device_bank_registry=self._device_bank_registry, name=u'Device', device_selection_follows_track_selection=True)
         self._device.set_enabled(False)
-        self._device.layer = Layer(parameter_controls=ButtonMatrixElement(rows=[parameter_controls]), bank_buttons=ButtonMatrixElement(rows=[bank_buttons]))
+## Change to this next line for rows=
+        self._device.layer = Layer(parameter_controls=ButtonMatrixElement(rows=[top_encoders, bottom_encoders]), bank_buttons=ButtonMatrixElement(rows=[bank_buttons]))
         self.set_device_component(self._device)
         self._device_navigation = DeviceNavigationComponent()
         self._device_navigation.set_enabled(False)

--- a/_Generic/Devices.py
+++ b/_Generic/Devices.py
@@ -671,15 +671,15 @@ def parameter_banks(device, device_dict=DEVICE_DICT):
                             except:
                                 parameter_indices = []
 
-                            if len(parameter_indices) != 8:
-                                return [ None for i in range(0, 8) ]
+                            if len(parameter_indices) != 16:
+                                return [ None for i in range(0, 16) ]
                             else:
                                 return [ device.parameters[i] if i != -1 else None for i in parameter_indices ]
                                 return
 
                         return map(_bank_parameters, range(0, banks))
 
-            return group(device_parameters_to_map(device), 8)
+            return group(device_parameters_to_map(device), 16)
 
     return []
 
@@ -717,7 +717,7 @@ def number_of_parameter_banks(device, device_dict=DEVICE_DICT):
                         return banks
 
             param_count = len(device.parameters[1:])
-            return param_count / 8 + (1 if param_count % 8 else 0)
+            return param_count / 16 + (1 if param_count % 8 else 0)
 
     return 0
 


### PR DESCRIPTION
Changing the generic Devices.py and specifically the Launch Control script, we can use Factory Preset 3 to map 16 parameters to the knobs (instead of the default 8).